### PR TITLE
v0.8 Release proposal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 lib
 generated-docs
 stats.json
+
+# JetBrains files
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## v0.8.0
+### Changes:
+ * Publish `normalizePathPattern` function
+ * Publish `AbstractPathPattern` - super class of `PathPattern` and `RelativePathPattern`
+ * Improve normalization - use string functions instead of regexp and add normalization options
+ * Make params generic types optional (`any` by default)
+### Breaking changes:
+ * Move `PathPattern.matchOneOf` to the external function `matchOneOf`
+ * Rename `PathPattern.getFormatedPath()` to `PathPattern.getPattern()`
+
+## v0.7.0
+ * Initial release

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This is a a wrapper aroud [path-to-regexp](https://github.com/pillarjs/path-to-regexp).
 
-## This package is not Production ready !
+## This package is not Production ready!
 
 This package is under developement, do not use it in production. 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "path-pattern",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A url matching lib to go with Realytics/react-router-magic",
   "author": "Etienne Dldc <etienne.dldc@outlook.fr>",
   "license": "MIT",
@@ -22,7 +22,9 @@
     "prepare": "npm run build",
     "test": "jest",
     "test:watch": "yarn test -- --watch",
-    "test:cov": "yarn test -- --coverage"
+    "test:cov": "yarn test -- --coverage",
+    "lint": "tslint \"src/**/*.ts?(x)\" \"test/**/*.ts?(x)\" -t stylish",
+    "lint:fix": "yarn lint -- --fix"
   },
   "repository": {
     "type": "git",
@@ -53,7 +55,13 @@
     "transform": {
       "\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testRegex": "(/test/.*\\.spec.(ts|tsx|js))$",
+    "collectCoverageFrom": [
+      "src/**/*"
+    ],
+    "coveragePathIgnorePatterns": [
+      "/src/.*\\.d\\.ts$"
+    ],
+    "testRegex": "/test/.*\\.spec\\.(ts|tsx|js)$",
     "mapCoverage": true
   },
   "bugs": {

--- a/src/AbstractPathPattern.ts
+++ b/src/AbstractPathPattern.ts
@@ -1,0 +1,29 @@
+
+import { Location } from 'history';
+import { normalizePathPattern } from './normalizePathPattern';
+import { Match } from './Match';
+import { Matchable, MatchOptions } from './Matchable';
+import { PatternAware } from './PatternAware';
+
+export abstract class AbstractPathPattern<Params> implements Matchable<Params>, PatternAware {
+
+  protected pattern: string;
+
+  constructor(pattern: string) {
+    this.pattern = normalizePathPattern(pattern);
+
+    this.matchAdvanced = this.matchAdvanced.bind(this);
+    this.match = this.match.bind(this);
+    this.matchExact = this.matchExact.bind(this);
+    this.matchStrict = this.matchStrict.bind(this);
+  }
+
+  getPattern(): string {
+    return this.pattern;
+  }
+
+  abstract matchAdvanced(options: MatchOptions): (location: Location) => Match<Params>;
+  abstract match(location: Location): Match<Params>;
+  abstract matchExact(location: Location): Match<Params>;
+  abstract matchStrict(location: Location): Match<Params>;
+}

--- a/src/InheritedPathPattern.ts
+++ b/src/InheritedPathPattern.ts
@@ -1,14 +1,13 @@
+import { normalizePathPattern } from './normalizePathPattern';
 import { PathPattern } from './PathPattern';
 
-export class InheritedPathPattern<ParentParams, Params> extends PathPattern<ParentParams & Params> {
+export class InheritedPathPattern<ParentParams = any, Params = any> extends PathPattern<ParentParams & Params> {
 
   constructor(
-    parentPath: PathPattern<ParentParams>,
-    path: string,
+    parentPathPattern: PathPattern<ParentParams>,
+    pattern: string
   ) {
-    const subPath: string = '/' + path.replace(/^(\/+)/, '');
-    const combinedPath: string = parentPath.getFormatedPath() + subPath;
-    super(combinedPath);
+    super(parentPathPattern.getPattern() + normalizePathPattern(pattern));
   }
 
 }

--- a/src/Match.ts
+++ b/src/Match.ts
@@ -1,0 +1,9 @@
+
+export type MatchSuccess<Params = any> = {
+  params: Params;
+  isExact: boolean;
+  path: string;
+  url: string;
+};
+
+export type Match<Params = any> = false | MatchSuccess<Params>;

--- a/src/Matchable.ts
+++ b/src/Matchable.ts
@@ -1,0 +1,21 @@
+import { Location } from 'history';
+import { Match } from './Match';
+
+export type MatchOptions = {
+  exact?: boolean;
+  strict?: boolean;
+};
+
+export interface Matchable<Params> {
+  matchAdvanced(options: MatchOptions): (location: Location) => Match<Params>;
+  match(location: Location): Match<Params>;
+  matchExact(location: Location): Match<Params>;
+  matchStrict(location: Location): Match<Params>;
+}
+
+export interface RelativeMatchable<ParentParams, Params> extends Matchable<Params> {
+  matchAdvanced(options: MatchOptions): (location: Location, parentMatch?: Match<ParentParams>) => Match<Params>;
+  match(location: Location, parentMatch?: Match<ParentParams>): Match<Params>;
+  matchExact(location: Location, parentMatch?: Match<ParentParams>): Match<Params>;
+  matchStrict(location: Location, parentMatch?: Match<ParentParams>): Match<Params>;
+}

--- a/src/Matcher.ts
+++ b/src/Matcher.ts
@@ -1,0 +1,5 @@
+
+import { Location } from 'history';
+import { Match } from './Match';
+
+export type Matcher<Params = any> = (location: Location) => Match<Params>;

--- a/src/PatternAware.ts
+++ b/src/PatternAware.ts
@@ -1,0 +1,4 @@
+
+export interface PatternAware {
+  getPattern(): string;
+}

--- a/src/RelativePathPattern.ts
+++ b/src/RelativePathPattern.ts
@@ -1,49 +1,41 @@
-import { PathPattern, MatchOptions, Match, IMatchable } from './PathPattern';
 import { Location } from 'history';
+import { AbstractPathPattern } from './AbstractPathPattern';
 import { InheritedPathPattern } from './InheritedPathPattern';
+import { Match } from './Match';
+import { MatchOptions, RelativeMatchable } from './Matchable';
+import { PathPattern } from './PathPattern';
 
-export class RelativePathPattern<ParentParams, Params>
-  implements IMatchable<ParentParams, Params> {
+export class RelativePathPattern<ParentParams = any, Params = any> extends AbstractPathPattern<Params>
+  implements RelativeMatchable<ParentParams, Params> {
 
-  constructor(private path: string) {
-    this.matchAdvanced = this.matchAdvanced.bind(this);
-    this.match = this.match.bind(this);
-    this.matchExact = this.matchExact.bind(this);
-    this.matchStrict = this.matchStrict.bind(this);
-  }
-
-  matchAdvanced(options: MatchOptions = {}): (location: Location, parentMatch: Match<ParentParams>) => Match<Params> {
-    return (location: Location, parentMatch: Match<ParentParams>) => {
+  matchAdvanced(options: MatchOptions = {}): (location: Location, parentMatch?: Match<ParentParams>) => Match<Params> {
+    return (location, parentMatch = false) => {
       if (parentMatch === false) {
         return false;
       }
-      const parentPattern: PathPattern<ParentParams> = new PathPattern<ParentParams>(parentMatch.path);
-      const pattern: InheritedPathPattern<ParentParams, Params> = new InheritedPathPattern<ParentParams, Params>(
-        parentPattern,
-        this.path,
-      );
+
+      const parentPattern = new PathPattern<ParentParams>(parentMatch.path);
+      const pattern = new InheritedPathPattern<ParentParams, Params>(parentPattern, this.pattern);
+
       return pattern.matchAdvanced(options)(location);
     };
   }
 
-  match(location: Location, parentMatch: Match<ParentParams>): Match<Params> {
+  match(location: Location, parentMatch?: Match<ParentParams>): Match<Params> {
     return this.matchAdvanced()(location, parentMatch);
   }
 
-  matchExact(location: Location, parentMatch: Match<ParentParams>): Match<Params> {
+  matchExact(location: Location, parentMatch?: Match<ParentParams>): Match<Params> {
     return this.matchAdvanced({ exact: true })(location, parentMatch);
   }
 
-  matchStrict(location: Location, parentMatch: Match<ParentParams>): Match<Params> {
+  matchStrict(location: Location, parentMatch?: Match<ParentParams>): Match<Params> {
     return this.matchAdvanced({ exact: true, strict: true })(location, parentMatch);
   }
 
   compile(parentPattern: PathPattern<ParentParams>, params?: ParentParams & Params): string {
-    const pattern: InheritedPathPattern<ParentParams, Params> = new InheritedPathPattern<ParentParams, Params>(
-      parentPattern,
-      this.path,
-    );
+    const pattern = new InheritedPathPattern<ParentParams, Params>(parentPattern, this.pattern);
+
     return pattern.compile(params);
   }
-
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
-export { PathPattern, Match, MatchSuccess, MatchOptions, IMatchable } from './PathPattern';
+export { AbstractPathPattern } from './AbstractPathPattern';
+export { PathPattern } from './PathPattern';
+export { Match, MatchSuccess } from './Match';
+export { MatchOptions, Matchable, RelativeMatchable } from './Matchable';
+export { Matcher } from './Matcher';
+export { PatternAware } from './PatternAware';
+export { normalizePathPattern } from './normalizePathPattern';
+export { matchOneOf } from './matchOneOf';
 export { InheritedPathPattern } from './InheritedPathPattern';
 export { RelativePathPattern } from './RelativePathPattern';

--- a/src/matchOneOf.ts
+++ b/src/matchOneOf.ts
@@ -1,0 +1,12 @@
+
+import { Matcher } from './Matcher';
+
+/**
+ * Reduce matchers to one matcher that selects first match.
+ *
+ * @param matchers Matchers to reduce
+ * @returns {Matcher} Reduced matcher
+ */
+export function matchOneOf(...matchers: Matcher[]): Matcher {
+  return location => matchers.reduce((match, matcher) => match || matcher(location), false as any);
+}

--- a/src/normalizePathPattern.ts
+++ b/src/normalizePathPattern.ts
@@ -1,0 +1,30 @@
+export type PathNormalizeOptions = {
+  strict?: boolean;
+  sensitive?: boolean;
+};
+
+/**
+ * Normalize path pattern - ensure it starts with slash and
+ *  - if options.sensitive is false - ensure it's lowercase, default false
+ *  - if options.strict is false - ensure it doesn't end with slash, default true
+ *
+ * @param pattern Pattern to normalize
+ * @param options Additional options for path normalization - { sensitive: boolean, strict: boolean }
+ * @returns {string} Normalized path
+ */
+export function normalizePathPattern(pattern: string, options: PathNormalizeOptions = {}): string {
+  const { sensitive = false, strict = true } = options;
+
+  let normalizedPath = '/' + (pattern[0] === '/' ? pattern.substr(1) : pattern);
+
+  if (!sensitive) {
+    normalizedPath = normalizedPath.toLowerCase();
+  }
+
+  if (!strict) {
+    normalizedPath = normalizedPath.length > 1 && normalizedPath[normalizedPath.length - 1] === '/' ?
+      normalizedPath.substr(0, normalizedPath.length - 1) : normalizedPath;
+  }
+
+  return normalizedPath;
+}

--- a/test/InheritedPathPattern.spec.ts
+++ b/test/InheritedPathPattern.spec.ts
@@ -1,6 +1,5 @@
-import { InheritedPathPattern } from '../src/InheritedPathPattern';
-import { PathPattern, Match } from '../src/PathPattern';
 import { Location } from 'history';
+import { InheritedPathPattern, PathPattern } from '../src';
 
 function createLocation(path: string = ''): Location {
   return {
@@ -14,8 +13,8 @@ function createLocation(path: string = ''): Location {
 
 describe('RelativePathPattern', () => {
 
-  const parentPattern: PathPattern<{}> = new PathPattern<{}>('/home');
-  const pattern: InheritedPathPattern<{}, {}> = new InheritedPathPattern<{}, {}>(parentPattern, '/user');
+  const parentPattern = new PathPattern('/home');
+  const pattern = new InheritedPathPattern(parentPattern, '/user');
 
   it('match /home/user', () => {
     expect(pattern.match(createLocation('/home/user'))).toBeTruthy();

--- a/test/PathPattern.spec.ts
+++ b/test/PathPattern.spec.ts
@@ -1,15 +1,6 @@
-import { PathPattern } from '../src/PathPattern';
 import { Location } from 'history';
-
-function createLocation(path: string = ''): Location {
-  return {
-    pathname: path,
-    hash: '',
-    key: '0uicnx',
-    search: '',
-    state: null,
-  };
-}
+import { PathPattern } from '../src';
+import { createLocation } from './utils/createLocation';
 
 describe(`new PathPattern('/home')`, () => {
   const pattern = new PathPattern('/home');
@@ -36,7 +27,7 @@ describe(`new PathPattern('/home', { exact: true })`, () => {
     expect(pattern.matchExact(createLocation('/welcome'))).toBeFalsy();
   });
   it(`does not match '/'`, () => { expect(pattern.matchExact(createLocation('/'))).toBeFalsy(); });
-  it(`get getFormatedPath`, () => { expect(pattern.getFormatedPath()).toEqual('/home'); });
+  it(`get getPattern`, () => { expect(pattern.getPattern()).toEqual('/home'); });
 });
 
 describe(`new PathPattern('/home/', { exact: true, strict: true })`, () => {
@@ -57,7 +48,7 @@ describe(`new PathPattern('/home/', { exact: true, strict: true })`, () => {
     expect(pattern.matchStrict(createLocation('/'))).toBeFalsy();
   });
   it(`compile to '/home'`, () => { expect(pattern.compile()).toEqual('/home/'); });
-  it(`get getFormatedPath`, () => { expect(pattern.getFormatedPath()).toEqual('/home'); });
+  it(`get getPattern`, () => { expect(pattern.getPattern()).toEqual('/home/'); });
 });
 
 // create twice the same path for coverage
@@ -100,7 +91,7 @@ describe(`new PathPattern('/user/:user')`, () => {
   it(`compile with user john`, () => {
     expect(pattern.compile({ user: 'john' })).toEqual('/user/john');
   });
-  it(`get getFormatedPath`, () => { expect(pattern.getFormatedPath()).toEqual('/user/:user'); });
+  it(`get getPattern`, () => { expect(pattern.getPattern()).toEqual('/user/:user'); });
 });
 
 describe(`new PathPattern('/')`, () => {
@@ -115,29 +106,5 @@ describe(`new PathPattern('home')`, () => {
   it(`match '/home/user'`, () => { expect(pattern.match(createLocation('/home/user'))).toBeTruthy(); });
   it(`does not match '/welcome'`, () => { expect(pattern.match(createLocation('/welcome'))).toBeFalsy(); });
   it(`does not match '/'`, () => { expect(pattern.match(createLocation('/'))).toBeFalsy(); });
-  it(`get getFormatedPath`, () => { expect(pattern.getFormatedPath()).toEqual('/home'); });
-});
-
-describe('PathPattern.matchOneOf', () => {
-  const pattern1 = new PathPattern('/home');
-  const pattern2 = new PathPattern('/hello');
-  it('match /home & /hello & /hello/welcome', () => {
-    const matcher = PathPattern.matchOneOf(
-      pattern1.match,
-      pattern2.match,
-    );
-    expect(matcher(createLocation('/home'))).toBeTruthy();
-    expect(matcher(createLocation('/hello'))).toBeTruthy();
-    expect(matcher(createLocation('/hello/welcome'))).toBeTruthy();
-  });
-
-  it('match /home & /hello exact but not /hello/welcome', () => {
-    const matcher = PathPattern.matchOneOf(
-      pattern1.match,
-      pattern2.matchExact,
-    );
-    expect(matcher(createLocation('/home'))).toBeTruthy();
-    expect(matcher(createLocation('/hello'))).toBeTruthy();
-    expect(matcher(createLocation('/hello/welcome'))).toBeFalsy();
-  });
+  it(`get getPattern`, () => { expect(pattern.getPattern()).toEqual('/home'); });
 });

--- a/test/RelativePathPattern.spec.ts
+++ b/test/RelativePathPattern.spec.ts
@@ -1,16 +1,5 @@
-import { RelativePathPattern } from '../src/RelativePathPattern';
-import { PathPattern, Match } from '../src/PathPattern';
-import { Location } from 'history';
-
-function createLocation(path: string = ''): Location {
-  return {
-    pathname: path,
-    hash: '',
-    key: '0uicnx',
-    search: '',
-    state: null,
-  };
-}
+import { Match, PathPattern, RelativePathPattern } from '../src';
+import { createLocation } from './utils/createLocation';
 
 describe('RelativePathPattern', () => {
 
@@ -50,14 +39,21 @@ describe('RelativePathPattern', () => {
     expect(pattern.compile(new PathPattern('/post'))).toEqual('/post/all');
   });
 
-  it('match /user/all', () => {
+  it('match exact /user/all', () => {
     expect(pattern.matchExact(createLocation('/user/all'), parentMatchUser)).toBeTruthy();
   });
-  it('match /user/all/desc', () => {
+  it('match exact /user/all/desc', () => {
     expect(pattern.matchExact(createLocation('/user/all/desc'), parentMatchUser)).toBeFalsy();
   });
-  it('does not match /user', () => {
+  it('does not match exact /user', () => {
     expect(pattern.matchExact(createLocation('/user'), parentMatchUser)).toBeFalsy();
+  });
+
+  it('match strict /user', () => {
+    expect(pattern.matchStrict(createLocation('/user/all'), parentMatchUser)).toBeTruthy();
+  });
+  it('does not match strict /user/', () => {
+    expect(pattern.matchStrict(createLocation('/user/all/'), parentMatchUser)).toBeFalsy();
   });
 
 });

--- a/test/matchOneOf.spec.ts
+++ b/test/matchOneOf.spec.ts
@@ -1,0 +1,27 @@
+
+import { matchOneOf, PathPattern } from '../src';
+import { createLocation } from './utils/createLocation';
+
+describe('matchOneOf', () => {
+  const pattern1 = new PathPattern('/home');
+  const pattern2 = new PathPattern('/hello');
+  it('match /home & /hello & /hello/welcome', () => {
+    const matcher = matchOneOf(
+      pattern1.match,
+      pattern2.match,
+    );
+    expect(matcher(createLocation('/home'))).toBeTruthy();
+    expect(matcher(createLocation('/hello'))).toBeTruthy();
+    expect(matcher(createLocation('/hello/welcome'))).toBeTruthy();
+  });
+
+  it('match /home & /hello exact but not /hello/welcome', () => {
+    const matcher = matchOneOf(
+      pattern1.match,
+      pattern2.matchExact,
+    );
+    expect(matcher(createLocation('/home'))).toBeTruthy();
+    expect(matcher(createLocation('/hello'))).toBeTruthy();
+    expect(matcher(createLocation('/hello/welcome'))).toBeFalsy();
+  });
+});

--- a/test/normalizePathPattern.spec.ts
+++ b/test/normalizePathPattern.spec.ts
@@ -1,0 +1,32 @@
+
+import { normalizePathPattern } from '../src';
+
+describe(`normalizePathPattern`, () => {
+  it('adds slash at the begin', () => {
+    expect(normalizePathPattern('home')).toEqual('/home');
+    expect(normalizePathPattern('home', { strict: true })).toEqual('/home');
+    expect(normalizePathPattern('home', { sensitive: false })).toEqual('/home');
+  });
+
+  it('strips trailing slash on strict: false', () => {
+    expect(normalizePathPattern('home/', { strict: true })).toEqual('/home/');
+    expect(normalizePathPattern('home/', { strict: false })).toEqual('/home');
+    expect(normalizePathPattern('home/')).toEqual('/home/');
+    expect(normalizePathPattern('/home/', { strict: true })).toEqual('/home/');
+    expect(normalizePathPattern('/home/', { strict: false })).toEqual('/home');
+    expect(normalizePathPattern('/home/')).toEqual('/home/');
+  });
+
+  it('lowercase path on sensitive: false', () => {
+    expect(normalizePathPattern('/HoMe', { sensitive: true })).toEqual('/HoMe');
+    expect(normalizePathPattern('/HoMe', { sensitive: false })).toEqual('/home');
+    expect(normalizePathPattern('/HoMe')).toEqual('/home');
+  });
+
+  it('should work for empty path', () => {
+    expect(normalizePathPattern('')).toEqual('/');
+    expect(normalizePathPattern('', { sensitive: true })).toEqual('/');
+    expect(normalizePathPattern('', { strict: false })).toEqual('/');
+    expect(normalizePathPattern('', { sensitive: true, strict: false })).toEqual('/');
+  });
+});

--- a/test/utils/createLocation.ts
+++ b/test/utils/createLocation.ts
@@ -1,0 +1,11 @@
+import { Location } from 'history';
+
+export function createLocation(path: string = ''): Location {
+  return {
+    pathname: path,
+    hash: '',
+    key: '0uicnx',
+    search: '',
+    state: null,
+  };
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,99 +1,32 @@
 {
+  "defaultSeverity": "warning",
+  "extends": [
+    "tslint:recommended"
+  ],
+  "jsRules": {},
   "rules": {
-    "no-duplicate-variable": true,
-    "no-internal-module": true,
-    "max-line-length": [true, 120],
-    "no-var-requires": true,
-    "only-arrow-functions": [
-      true,
-      "allow-declarations"
-    ],
-    "typedef-whitespace": [
+    "trailing-comma": false,
+    "max-line-length": [true, 140],
+    "quotemark": [true, "single"],
+    "array-type": [true, "array"],
+    "arrow-parens": false,
+    "member-access": [true, "no-public"],
+    "interface-over-type-literal": false,
+    "interface-name": false,
+    "no-namespace": false,
+    "no-string-literal": false,
+    "no-empty-interface": false,
+    "object-literal-key-quotes": false,
+    "object-literal-shorthand": false,
+    "object-literal-sort-keys": false,
+    "callable-types": false,
+    "ordered-imports": [
       true,
       {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
+        "import-sources-order": "lowercase-first",
+        "named-imports-order": "lowercase-first"
       }
-    ],
-    "curly": true,
-    "no-conditional-assignment": true,
-    "no-console": [
-      true,
-      "log"
-    ],
-    "no-construct": true,
-    "no-eval": true,
-    "no-empty": true,
-    "no-unsafe-finally": true,
-    "no-var-keyword": true,
-    "radix": true,
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
-    "eofline": true,
-    "indent": [
-      true,
-      "spaces"
-    ],
-    "linebreak-style": [
-      true,
-      "LF"
-    ],
-    "no-default-export": true,
-    "no-require-imports": false,
-    "no-trailing-whitespace": true,
-    "trailing-comma": [true, {
-      "multiline": "always",
-      "singleline": "never"
-    }],
-    "class-name": true,
-    "comment-format": [
-      true,
-      "check-space",
-      "check-lowercase"
-    ],
-    "interface-name": [
-      true,
-      "always-prefix"
-    ],
-    "no-consecutive-blank-lines": [true, 1],
-    "one-line": [
-      true,
-      "check-open-brace",
-      "check-whitespace"
-    ],
-    "object-literal-key-quotes": [
-      true,
-      "as-needed"
-    ],
-    "one-variable-per-declaration": [
-      true,
-      "ignore-for-loop"
-    ],
-    "quotemark": [
-      true,
-      "single",
-      "avoid-escape"
-    ],
-    "semicolon": [
-      true,
-      "always"
-    ],
-    "variable-name": [
-      true,
-      "ban-keywords"
-    ],
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
     ]
-  }
+  },
+  "rulesDirectory": []
 }


### PR DESCRIPTION
### Changes:
 * Publish `normalizePathPattern` function
 * Publish `AbstractPathPattern` - super class of `PathPattern` and `RelativePathPattern`
 * Improve normalization - use string functions instead of regexp and add normalization options
 * Make params generic types optional (`any` by default)
### Breaking changes:
 * Move `PathPattern.matchOneOf` to the external function `matchOneOf`
 * Rename `PathPattern.getFormatedPath()` to `PathPattern.getPattern()`
